### PR TITLE
interface, formatting and output update

### DIFF
--- a/src/address.ts
+++ b/src/address.ts
@@ -2,31 +2,13 @@ import path from "path";
 import { loadFileAsString } from "./file";
 import { STREET_ADDRESSES } from "./env";
 
-// Define Address parts to avoid type based errrors
-interface Address {
-  full: string; // as it presented in the source file
-  number: number; // street address number
-  street: string; // street name
-  city: string; // city name
-  state: string; // state name or code
-  zip: number; // numerical zip code
-}
-
-// Used to enumerate parts of the address as expected in the file
-enum AddressPart {
-  NUMBER_AND_STREET,
-  CITY,
-  STATE,
-  ZIP,
-}
-
 /**
  * Formats string input for Addresses
  * @param addressInput  string - String input to be formatted into array of Addresses
  *                      If value is not supplied, the program will attempt to retrieve the input via a file path configured at environment level
  * @returns Array of Address objects
  */
-function getStreetAddresses(addressInput: string = ""): Address[] {
+function getStreetAddresses(addressInput: string = ""): string[] {
   if (!addressInput) {
     // Get input from file
     const filePath = path.resolve(__dirname, STREET_ADDRESSES);
@@ -38,23 +20,9 @@ function getStreetAddresses(addressInput: string = ""): Address[] {
     addressInput = result;
   }
   // Format Addresses
-  const addressess: Address[] = addressInput.split("\n").map((line: string) => {
-    const addressParts = line.split(",");
-    const numberAndStreet = addressParts[AddressPart.NUMBER_AND_STREET]
-      ?.trim()
-      ?.split(/\s/);
-    const address: Address = {
-      full: line.trim(),
-      number: parseInt(numberAndStreet?.[0]) || 0,
-      street: numberAndStreet?.[1] || "",
-      city: addressParts[AddressPart.CITY]?.trim() || "",
-      state: addressParts[AddressPart.STATE]?.trim() || "",
-      zip: parseInt(addressParts[AddressPart.ZIP]?.trim()) || 0,
-    };
-    return address;
-  });
+  const addressess: string[] = addressInput.split("\n").map((line: string) => line.trim());
 
   return addressess;
 }
 
-export { getStreetAddresses, Address };
+export { getStreetAddresses };

--- a/src/address.ts
+++ b/src/address.ts
@@ -6,7 +6,7 @@ import { STREET_ADDRESSES } from "./env";
  * Formats string input for Addresses
  * @param addressInput  string - String input to be formatted into array of Addresses
  *                      If value is not supplied, the program will attempt to retrieve the input via a file path configured at environment level
- * @returns Array of Address objects
+ * @returns Array of Address strings
  */
 function getStreetAddresses(addressInput: string = ""): string[] {
   if (!addressInput) {

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -2,19 +2,13 @@ import path from "path";
 import { loadFileAsString } from "./file";
 import { DRIVER_NAMES } from "./env";
 
-// Define Driver parts to avoid type based errrors
-interface Driver {
-  name: string;         // as it is respresented in the file,
-  nameCondensed: string // white-space and special characters removed
-}
-
 /**
  * Formats string input for Drivers
  * @param addressInput  string - String input to be formatted into array of Drivers
  *                      If value is not supplied, the program will attempt to retrieve the input via a file path configured at environment level
  * @returns array of Driver objects
  */
-function getDrivers(driverInput: string = ''): Driver[] {
+function getDrivers(driverInput: string = ''): string[] {
   if (!driverInput) {
     // Get input from file
     const filePath = path.resolve(__dirname, DRIVER_NAMES);
@@ -26,16 +20,9 @@ function getDrivers(driverInput: string = ''): Driver[] {
     driverInput = result;
   }
   // Format drivers
-  const drivers = driverInput.split("\n").map((line: string) => {
-    const nameTrimmed = line.trim();
-    const driver: Driver = {
-      name: nameTrimmed,
-      nameCondensed: nameTrimmed.replace(/[^A-Za-z]/g, '').toLowerCase()
-    };
-    return driver;
-  });
+  const drivers = driverInput.split("\n").map((line: string) => line.trim());
 
   return drivers;
 }
 
-export { getDrivers, Driver };
+export { getDrivers };

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -4,9 +4,9 @@ import { DRIVER_NAMES } from "./env";
 
 /**
  * Formats string input for Drivers
- * @param addressInput  string - String input to be formatted into array of Drivers
+ * @param driverInput  string - String input to be formatted into array of Drivers
  *                      If value is not supplied, the program will attempt to retrieve the input via a file path configured at environment level
- * @returns array of Driver objects
+ * @returns array of Driver strings
  */
 function getDrivers(driverInput: string = ''): string[] {
   if (!driverInput) {

--- a/src/suitabilityScore.ts
+++ b/src/suitabilityScore.ts
@@ -1,23 +1,3 @@
-import { Driver } from "./driver";
-import { Address } from "./address";
-
-/**
- * Gets the number of vowels in a word
- * @param word
- * @returns number
- */
-function countVowels(word: string): number {
-  const vowels = "aeiouAEIOU";
-  let count = 0;
-  for (let i = 0; i < word.length; i++) {
-    const char = word.charAt(i);
-    if (vowels.indexOf(char) !== -1 && char !== " ") {
-      count++;
-    }
-  }
-  return count;
-}
-
 /**
  * Gets the greatest common divisor shared between two numbers
  * @param x number
@@ -41,7 +21,7 @@ function greatestCommonDivisor(x: number, y: number): number {
  * @param destination - Address
  * @returns number
  */
-function suitabilityScore(driver: Driver, destination: Address): number {
+function suitabilityScore(driver: string, destination: string): number {
   // Calculate base SS value per the "top-secret algorithm" instructions:
   // ● If the length of the shipment's destination street name is even, the base
   //   suitability score (SS) is the number of vowels in the driver’s name multiplied by
@@ -50,27 +30,28 @@ function suitabilityScore(driver: Driver, destination: Address): number {
   //   number of consonants in the driver’s name multiplied by 1.
   // ● If the length of the shipment's destination street name shares any common
   //   factors (besides 1) with the length of the driver’s name, the SS is increased by
-  //   50% above the base SS 
-
+  //   50% above the base SS
+  
+  const street = destination?.match(/\d+\s([^,]+)/)?.[1]?.trim() || ''
   // Determine base score
-  const streetNameIsEven: boolean = destination.street.length % 2 ? false : true;
-  const vowels: number = countVowels(driver.name);
+  const streetNameIsEven: boolean =
+    street.length % 2 ? false : true;
   const baseLetterCount: number = streetNameIsEven
-    ? vowels
-    : driver.nameCondensed.length - vowels; // consonants
-  const baseMultiplier: number = streetNameIsEven ? 1.5 : 1;
-  const base: number = baseLetterCount * baseMultiplier;
+    ? driver.match(/[aeiou]/gi)?.length || 0 // vowel count
+    : driver.match(/[bcdfghj-np-tv-z]/gi)?.length || 0; // consonant count
+  const base: number = streetNameIsEven
+    ? baseLetterCount * 1.5
+    : baseLetterCount;
 
   // Determine if common factors exist
-  const streetNameLength: number = destination.street.length;
-  const driverNameLength: number = driver.name.length;
+  const streetNameLength: number = street.length;
+  const driverNameLength: number = driver.length;
   const gcd: number = greatestCommonDivisor(streetNameLength, driverNameLength);
   const hasCommonFactors: boolean =
     gcd > 1 && gcd !== streetNameLength && gcd !== driverNameLength;
 
-    // set suitability score and apply 50% increase if common factors exist
+  // set suitability score and apply 50% increase if common factors exist
   const ss: number = hasCommonFactors ? base * 1.5 : base;
-
   return ss;
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -23,8 +23,8 @@ const SS_CASES = [
         // base SS: 9
         // common factors (other than 1): none
         // No further multipliers: use base SS (9)
-        driver: { name: 'Daniel Davidson', nameCondensed: 'danieldavidson' },
-        address: { number: 44, street: 'Fake Dr.', city: 'San Diego', state: 'CA', zip: 92122 },
+        driver: 'Daniel Davidson',
+        address: '44 Fake Dr., San Diego, CA, 92122',
         expect: 9
     },
     // Further test cases only have information required to run the suitabilityScore function properly
@@ -38,8 +38,8 @@ const SS_CASES = [
         // base SS: 6
         // common factors (other than 1): 2
         // 6 * 1.5 = 9
-        driver: { name: 'Bob Dolewhip', nameCondensed: 'bobdolewhip' },
-        address: { street: 'Moneybags Lane' },
+        driver: 'Bob Dolewhip',
+        address: '123 Moneybags Lane, Williamsburg, IN, 55555',
         expect: 9
     },
     {
@@ -51,8 +51,8 @@ const SS_CASES = [
         // base SS: 4
         // common factors (other than 1): none
         // No further multipliers: use base SS (4)
-        driver: { name: 'Bob Obb', nameCondensed: 'bobobb' },
-        address: { street: 'Paseo Roberto' },
+        driver: 'Bob Obb',
+        address: ' 990 Paseo Roberto, Singleton, WA, 49813',
         expect: 4
     },
     {
@@ -65,8 +65,8 @@ const SS_CASES = [
         // 7 * 1.5 = 10.5
         // common factors (other than 1): 7
         // 10.5 * 1.5 = 15.75
-        driver: { name: 'Joshua Almanza Bracks', nameCondensed: 'joshuaalmanzabracks' },
-        address: { street: 'Corona Del Mar' },
+        driver: 'Joshua Almanza Bracks',
+        address: '405 Corona Del Mar, Someplace, CA, 91710',
         expect: 15.75
     }
 ]


### PR DESCRIPTION
- Removed a good deal of extra formatting and interfaces that, while useful while writing the initial algorithm, are ultimately unnecessary and can lead to a bit of performance loss.  Namely, the `Driver` and `Address` interfaces were removed and all functions that used them previously handle strings directly.
- Changed output file from an array of `driver/address/score` objects to a single total score `ss` and an array of `driver/address` objects.
- Replaced the `countVowels` helper function used during `suitabilityScore` with a pair of RegExp matches for vowels and consonants, respectively.
- Updated the unit test cases to pass strings instead of Driver/Address objects.
- Renamed `getNumericalCombinations` to `getCombinationsAndSuitabilityScores`
- Moved suitability score calculation from `getAssignments` where calculations had to be run multiple times, to `getCombinationsAndSuitabilityScores` so that each calculation only has to be run once.  This also reduces the number of total iterations have to be run during the entirety of the `getAssignments` function.
- Changed the inputs for `getCombinationsAndSuitabilityScores` from `driverCount: number` to `drivers: string[]` and from `addressCount: number` to `addresses: string[]` to accommodate for changes made in the previous bullet point.